### PR TITLE
style : unlock comment coding css style

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,8 @@
 `"use client"`;
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-// import "./globals.css";
-// import "../style/markdown.css";
+import "./globals.css";
+import "../style/markdown.css";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/style/markdown.css
+++ b/style/markdown.css
@@ -1,4 +1,4 @@
-/* h1 {
+h1 {
   font-size: 2rem;
   font-weight: bold;
 }
@@ -16,4 +16,4 @@ pre {
   padding: 1rem;
   border-radius: 8px;
   overflow: auto;
-} */
+}


### PR DESCRIPTION
nothing much unlock only commit

This pull request includes changes to the `app/layout.tsx` and `style/markdown.css` files to re-enable CSS imports and adjust styling for headers and preformatted text.

Re-enabling CSS imports:

* [`app/layout.tsx`](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL4-R5): Uncommented lines to re-import `globals.css` and `markdown.css` for global styles.

Styling adjustments:

* [`style/markdown.css`](diffhunk://#diff-238a0335acb3cf9ef7385734c37f8d3e465cc423da36f7220951d6677016f5f9L1-R1): Uncommented the `h1` selector to apply font size and weight styles to header elements.
* [`style/markdown.css`](diffhunk://#diff-238a0335acb3cf9ef7385734c37f8d3e465cc423da36f7220951d6677016f5f9L19-R19): Uncommented the `pre` selector to apply padding, border-radius, and overflow styles to preformatted text blocks.